### PR TITLE
Fix bteil export formatting issues

### DIFF
--- a/sitzungsexport/bookstack.py
+++ b/sitzungsexport/bookstack.py
@@ -31,7 +31,7 @@ class WikiInterface(ABC):
                         name=f"Sitzung {date} B-Teil {i}",
                         book="Sitzungsprotokolle (B-Teile)",
                         chapter=chapter_name,
-                        text=bteil.content,
+                        text=bteil.compile(),
                     )
                     bar.update(1)
                     bteil.replacement = f"\n > {{{{@{page_id}}}}}\n"

--- a/sitzungsexport/cli.py
+++ b/sitzungsexport/cli.py
@@ -28,8 +28,16 @@ def post(url: str, username: str, password: str, protocolfile):
 @cli.command("preview", help="Render a preview of the protocol")
 @click.argument("protocolfile", type=click.File("r"))
 def preview(protocolfile):
-    protocol = Protocol(protocolfile.read(), preview=True)
+    protocol = Protocol(protocolfile.read())
+
+    print('====A-Teil====')
     print(protocol.compile())
+
+    print('====B-Teile====')
+
+    for i, bteil in enumerate(protocol.bteile):
+        print(f'==B-Teil {i}==')
+        print(bteil.compile())
 
 
 if __name__ == "__main__":

--- a/sitzungsexport/cli.py
+++ b/sitzungsexport/cli.py
@@ -29,16 +29,7 @@ def post(url: str, username: str, password: str, protocolfile):
 @click.argument("protocolfile", type=click.File("r"))
 def preview(protocolfile):
     protocol = Protocol(protocolfile.read())
-
-    print('====A-Teil====')
     print(protocol.compile())
-
-    print('====B-Teile====')
-
-    for i, bteil in enumerate(protocol.bteile):
-        print(f'==B-Teil {i}==')
-        print(bteil.compile())
-
 
 if __name__ == "__main__":
     if 'sentry' in environ:

--- a/sitzungsexport/models.py
+++ b/sitzungsexport/models.py
@@ -43,7 +43,7 @@ class Protocol:
             bteil_replacement = bteil.replacement
 
             if not bteil_replacement:
-                bteil_replacement = f'{{B-Teil {i}}}\n'
+                bteil_replacement = f"<b-teil>\n{bteil.compile()}</b-teil>"
 
             output = output.replace(
                 self.REPLACEMENT_PATTERN.format(i), bteil_replacement # type: ignore


### PR DESCRIPTION
Hey,

after reading issue #1 and experimenting a little bit with the code I may have fixed the error.

The problem resulted from the missing compilation of bteil sections andtThus bteil sections were not formatted at all, including indention, tables, etc.

To keep consistency within the program and not changing the actual model objects for the protocol, I have decided to remove the `preview` parameter of the `Protocol` class and added a `compile` method to the `bteil` class. This method is now called for both: preview generation and BookStack export.

In contrast to the previous version the preview mode does not include the bteil sections in the protocol directly anymore (which was the case because bteil sections were not stripped because of the `preview` parameter was set to `True`) and instead prints them after the ateil protocol section separately.

Thanks to @GeneralGeki for giving a good starting point to take a look at.

Please note, that the export function was only tested locally in preview mode while the BookStack export should work from my current understanding of the bug.

~FireSpike